### PR TITLE
Align frontend API clients with Sponsors Club API schema

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -29,6 +29,8 @@ export const AuthProvider = ({ children }) => {
     const pathname = usePathname();
 
     useEffect(() => {
+        if (typeof window === "undefined") return;
+
         const storedToken = localStorage.getItem("accessToken");
 
         if (storedToken) {
@@ -57,13 +59,17 @@ export const AuthProvider = ({ children }) => {
     // Fonction pour rafraîchir le token et mettre à jour l'utilisateur
     const refreshAuth = async () => {
         try {
+            if (typeof window === "undefined") {
+                throw new Error("No refresh token found");
+            }
+
             const refreshToken = localStorage.getItem("refreshToken");
             if (!refreshToken) throw new Error("No refresh token found");
 
-            const data = await refreshAccessToken(refreshToken);
-            localStorage.setItem("accessToken", data.access);
-            setAccessToken(data.access);
-            setUser(jwtDecode(data.access)); // Mettre à jour l'utilisateur
+            const newAccessToken = await refreshAccessToken(refreshToken);
+            localStorage.setItem("accessToken", newAccessToken);
+            setAccessToken(newAccessToken);
+            setUser(jwtDecode(newAccessToken)); // Mettre à jour l'utilisateur
         } catch (error) {
             console.error("Token refresh failed");
             router.replace("/login");

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,17 +1,30 @@
 
-// Prefer env override if provided, fallback to documented local API
-const DEFAULT_API_BASE = "http://localhost:8000/api";
+// Prefer env override if provided, fallback to documented local API host
+const DEFAULT_API_BASE = "http://localhost:8000";
 const rawBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || DEFAULT_API_BASE;
 
 // Normalise the base URL so we never end with a trailing slash
 export const API_BASE_URL = rawBaseUrl.replace(/\/$/, "");
 
-const makeUrl = (endpoint) =>
-  `${API_BASE_URL}${endpoint.startsWith("/") ? "" : "/"}${endpoint}`;
+const API_PATH_PREFIX = "/api";
+
+const normaliseEndpoint = (endpoint) =>
+  endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+
+export const makeApiUrl = (endpoint) => {
+  const normalisedEndpoint = normaliseEndpoint(endpoint);
+  const needsPrefix =
+    normalisedEndpoint !== API_PATH_PREFIX &&
+    !normalisedEndpoint.startsWith(`${API_PATH_PREFIX}/`);
+  const path = needsPrefix
+    ? `${API_PATH_PREFIX}${normalisedEndpoint}`
+    : normalisedEndpoint;
+  return `${API_BASE_URL}${path}`;
+};
 
 // 🔹 Reset Password Request
 export const resetPassword = async (email) => {
-  const res = await fetch(makeUrl("/users/password/reset/"), {
+  const res = await fetch(makeApiUrl("/users/password/reset/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -28,7 +41,7 @@ export const resetPassword = async (email) => {
 
 // 🔹 Confirm Password Reset
 export const confirmPasswordReset = async (token, newPassword) => {
-  const res = await fetch(makeUrl("/users/password/reset/confirm/"), {
+  const res = await fetch(makeApiUrl("/users/password/reset/confirm/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -43,7 +56,7 @@ export const confirmPasswordReset = async (token, newPassword) => {
 
 // 🔹 Register a new user
 export const registerUser = async (userData) => {
-  const res = await fetch(makeUrl("/users/register/"), {
+  const res = await fetch(makeApiUrl("/users/register/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -61,7 +74,7 @@ export const registerUser = async (userData) => {
 
 // 🔹 Verify Email
 export const verifyEmail = async (token) => {
-  const res = await fetch(makeUrl("/users/verify-email/"), {
+  const res = await fetch(makeApiUrl("/users/verify-email/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token }),
@@ -89,7 +102,7 @@ const withAuthIfAvailable = () => {
 };
 
 export const getAthletes = async () => {
-  const res = await fetch(makeUrl("/athletes/"), {
+  const res = await fetch(makeApiUrl("/athletes/"), {
     cache: "no-store",
     headers: { ...withAuthIfAvailable() },
   });
@@ -103,7 +116,7 @@ export const getAthleteBySlug = async (slugOrId) => {
   // Try fetch by UUID first, else fallback to list and match by profile_url
   const isUuid = /[0-9a-fA-F-]{36}/.test(slugOrId);
   if (isUuid) {
-    const res = await fetch(makeUrl(`/athletes/${slugOrId}/`), {
+    const res = await fetch(makeApiUrl(`/athletes/${slugOrId}/`), {
       cache: "no-store",
       headers: { ...withAuthIfAvailable() },
     });
@@ -118,7 +131,7 @@ export const getAthletesPage = async (pageSize = 12, page = 1) => {
     page: String(page),
     page_size: String(pageSize),
   });
-  const url = `${makeUrl("/athletes/")}?${params.toString()}`;
+  const url = `${makeApiUrl("/athletes/")}?${params.toString()}`;
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) throw new Error("Impossible de charger les athlètes");
   const data = await res.json();
@@ -128,7 +141,7 @@ export const getAthletesPage = async (pageSize = 12, page = 1) => {
     const end = start + pageSize;
     return {
       results: data.slice(start, end),
-      next: end < data.length ? `${makeUrl("/athletes/")}?${new URLSearchParams({
+      next: end < data.length ? `${makeApiUrl("/athletes/")}?${new URLSearchParams({
         page: String(page + 1),
         page_size: String(pageSize),
       }).toString()}` : null,
@@ -138,7 +151,7 @@ export const getAthletesPage = async (pageSize = 12, page = 1) => {
 };
 
 export const login = async (email, password) => {
-  const res = await fetch(makeUrl("/users/login/"), {
+  const res = await fetch(makeApiUrl("/users/login/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -177,7 +190,7 @@ export const refreshAccessToken = async (refreshTokenParam) => {
       : null);
   if (!refreshToken) throw new Error("No refresh token available");
 
-  const res = await fetch(makeUrl("/users/refresh/"), {
+  const res = await fetch(makeApiUrl("/users/refresh/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -213,14 +226,14 @@ export const fetchUserProfile = async () => {
   let token = storedToken;
   if (!token) throw new Error("User not authenticated");
 
-  let res = await fetch(makeUrl("/users/me/"), {
+  let res = await fetch(makeApiUrl("/users/me/"), {
     method: "GET",
     headers: { Authorization: `Bearer ${token}` },
   });
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(makeUrl("/users/me/"), {
+    res = await fetch(makeApiUrl("/users/me/"), {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -241,7 +254,7 @@ export const updateProfile = async (_id, data) => {
     throw new Error("Les données de mise à jour doivent être un objet JSON valide");
   }
 
-  let res = await fetch(makeUrl("/users/me/"), {
+  let res = await fetch(makeApiUrl("/users/me/"), {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -252,7 +265,7 @@ export const updateProfile = async (_id, data) => {
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(makeUrl("/users/me/"), {
+    res = await fetch(makeApiUrl("/users/me/"), {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -273,7 +286,7 @@ export const updateProfile = async (_id, data) => {
 
 // 🔹 Request Password Reset
 export const requestPasswordReset = async (email) => {
-  const res = await fetch(makeUrl("/users/password/reset/"), {
+  const res = await fetch(makeApiUrl("/users/password/reset/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email }),
@@ -292,7 +305,7 @@ export const changePassword = async (oldPassword, newPassword, confirmNewPasswor
     typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
   if (!token) throw new Error("User not authenticated");
 
-  let res = await fetch(makeUrl("/users/password/change/"), {
+  let res = await fetch(makeApiUrl("/users/password/change/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -307,7 +320,7 @@ export const changePassword = async (oldPassword, newPassword, confirmNewPasswor
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(makeUrl("/users/password/change/"), {
+    res = await fetch(makeApiUrl("/users/password/change/"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -331,7 +344,7 @@ export const deleteAccount = async () => {
     typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
   if (!token) throw new Error("User not authenticated");
 
-  let res = await fetch(makeUrl("/users/me/"), {
+  let res = await fetch(makeApiUrl("/users/me/"), {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
@@ -341,7 +354,7 @@ export const deleteAccount = async () => {
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(makeUrl("/users/me/"), {
+    res = await fetch(makeApiUrl("/users/me/"), {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,10 +1,17 @@
 
-// Prefer env override if provided, fallback to localhost
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8001";
+// Prefer env override if provided, fallback to documented local API
+const DEFAULT_API_BASE = "http://localhost:8000/api";
+const rawBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || DEFAULT_API_BASE;
+
+// Normalise the base URL so we never end with a trailing slash
+export const API_BASE_URL = rawBaseUrl.replace(/\/$/, "");
+
+const makeUrl = (endpoint) =>
+  `${API_BASE_URL}${endpoint.startsWith("/") ? "" : "/"}${endpoint}`;
 
 // 🔹 Reset Password Request
 export const resetPassword = async (email) => {
-  const res = await fetch(`${API_BASE_URL}/api/auth/reset-password/`, {
+  const res = await fetch(makeUrl("/users/password/reset/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -21,7 +28,7 @@ export const resetPassword = async (email) => {
 
 // 🔹 Confirm Password Reset
 export const confirmPasswordReset = async (token, newPassword) => {
-  const res = await fetch(`${API_BASE_URL}/api/auth/reset-password/confirm/`, {
+  const res = await fetch(makeUrl("/users/password/reset/confirm/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -36,7 +43,7 @@ export const confirmPasswordReset = async (token, newPassword) => {
 
 // 🔹 Register a new user
 export const registerUser = async (userData) => {
-  const res = await fetch(`${API_BASE_URL}/api/auth/register/`, {
+  const res = await fetch(makeUrl("/users/register/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -54,7 +61,7 @@ export const registerUser = async (userData) => {
 
 // 🔹 Verify Email
 export const verifyEmail = async (token) => {
-  const res = await fetch(`${API_BASE_URL}/api/auth/verify-email/`, {
+  const res = await fetch(makeUrl("/users/verify-email/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token }),
@@ -73,7 +80,7 @@ export const verifyEmail = async (token) => {
 // Helper: attach Authorization header if accessToken is available (for user-scoped fields like is_followed)
 const withAuthIfAvailable = () => {
   try {
-    if (typeof window === 'undefined') return {};
+    if (typeof window === "undefined") return {};
     const token = localStorage.getItem("accessToken");
     return token ? { Authorization: `Bearer ${token}` } : {};
   } catch {
@@ -82,7 +89,7 @@ const withAuthIfAvailable = () => {
 };
 
 export const getAthletes = async () => {
-  const res = await fetch(`${API_BASE_URL}/api/athletes/`, {
+  const res = await fetch(makeUrl("/athletes/"), {
     cache: "no-store",
     headers: { ...withAuthIfAvailable() },
   });
@@ -96,7 +103,7 @@ export const getAthleteBySlug = async (slugOrId) => {
   // Try fetch by UUID first, else fallback to list and match by profile_url
   const isUuid = /[0-9a-fA-F-]{36}/.test(slugOrId);
   if (isUuid) {
-    const res = await fetch(`${API_BASE_URL}/api/athletes/${slugOrId}/`, {
+    const res = await fetch(makeUrl(`/athletes/${slugOrId}/`), {
       cache: "no-store",
       headers: { ...withAuthIfAvailable() },
     });
@@ -106,20 +113,32 @@ export const getAthleteBySlug = async (slugOrId) => {
   return list.find((a) => a.profile_url === `/athletes/${slugOrId}` || a.id === slugOrId) || null;
 };
 
-export const getAthletesPage = async (limit = 12, offset = 0) => {
-  const url = `${API_BASE_URL}/api/athletes/?limit=${limit}&offset=${offset}`;
+export const getAthletesPage = async (pageSize = 12, page = 1) => {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+  });
+  const url = `${makeUrl("/athletes/")}?${params.toString()}`;
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) throw new Error("Impossible de charger les athlètes");
   const data = await res.json();
   if (Array.isArray(data)) {
     // non-paginated fallback
-    return { results: data.slice(offset, offset + limit), next: data.length > offset + limit ? url : null };
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    return {
+      results: data.slice(start, end),
+      next: end < data.length ? `${makeUrl("/athletes/")}?${new URLSearchParams({
+        page: String(page + 1),
+        page_size: String(pageSize),
+      }).toString()}` : null,
+    };
   }
   return { results: data.results || [], next: data.next || null };
 };
 
 export const login = async (email, password) => {
-  const res = await fetch(`${API_BASE_URL}/api/auth/login/`, {
+  const res = await fetch(makeUrl("/users/login/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -142,17 +161,23 @@ export const login = async (email, password) => {
   }
 
   // Sauvegarde des tokens dans le localStorage
-  localStorage.setItem("accessToken", data.access);
-  localStorage.setItem("refreshToken", data.refresh);
+  if (typeof window !== "undefined") {
+    localStorage.setItem("accessToken", data.access);
+    localStorage.setItem("refreshToken", data.refresh);
+  }
   return data;
 };
 
 // 🔹 Refresh Access Token
-export const refreshAccessToken = async () => {
-  const refreshToken = localStorage.getItem("refreshToken");
+export const refreshAccessToken = async (refreshTokenParam) => {
+  const refreshToken =
+    refreshTokenParam ||
+    (typeof window !== "undefined"
+      ? localStorage.getItem("refreshToken")
+      : null);
   if (!refreshToken) throw new Error("No refresh token available");
 
-  const res = await fetch(`${API_BASE_URL}/api/auth/refresh/`, {
+  const res = await fetch(makeUrl("/users/refresh/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -165,33 +190,37 @@ export const refreshAccessToken = async () => {
   }
 
   const data = await res.json();
-  localStorage.setItem("accessToken", data.access);
+  if (typeof window !== "undefined") {
+    localStorage.setItem("accessToken", data.access);
+  }
   return data.access;
 };
 
 // 🔹 Logout User
 export const logout = () => {
+  if (typeof window === "undefined") return;
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
 
   // Redirect to login page
   window.location.href = "/login?origin=logout";
-  
 };
 
 // 🔹 Fetch User Profile
 export const fetchUserProfile = async () => {
-  let token = localStorage.getItem("accessToken");
+  const storedToken =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+  let token = storedToken;
   if (!token) throw new Error("User not authenticated");
 
-  let res = await fetch(`${API_BASE_URL}/api/auth/me/`, {
+  let res = await fetch(makeUrl("/users/me/"), {
     method: "GET",
     headers: { Authorization: `Bearer ${token}` },
   });
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(`${API_BASE_URL}/api/auth/me/`, {
+    res = await fetch(makeUrl("/users/me/"), {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -203,38 +232,33 @@ export const fetchUserProfile = async () => {
 
 // 🔹 Update User Profile
 // 🔹 Mettre à jour le profil utilisateur avec PATCH
-export const updateProfile = async (id, data) => {
-  let token = localStorage.getItem("accessToken");
-  console.log(data);
+export const updateProfile = async (_id, data) => {
+  let token =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
   if (!token) throw new Error("Utilisateur non authentifié");
 
-  // 🔥 Récupérer l'ID utilisateur via fetchUserProfile()
-  const user = await fetchUserProfile();
-  const userId = user.id; // Assurez-vous que l'ID est bien récupéré depuis le profil utilisateur
-
-  // ✅ Vérification de la structure du payload avant l'envoi
   if (typeof data !== "object") {
     throw new Error("Les données de mise à jour doivent être un objet JSON valide");
   }
 
-  let res = await fetch(`${API_BASE_URL}/api/users/${userId}/`, {
-    method: "PATCH", // ✅ Utilisation de PATCH pour ne modifier que certains champs
+  let res = await fetch(makeUrl("/users/me/"), {
+    method: "PATCH",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify(data), // ✅ S'assurer que data est bien stringifié
+    body: JSON.stringify(data),
   });
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(`${API_BASE_URL}/api/users/${userId}/`, {
+    res = await fetch(makeUrl("/users/me/"), {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify(data), // ✅ Même correction ici
+      body: JSON.stringify(data),
     });
   }
 
@@ -249,7 +273,7 @@ export const updateProfile = async (id, data) => {
 
 // 🔹 Request Password Reset
 export const requestPasswordReset = async (email) => {
-  const res = await fetch(`${API_BASE_URL}/api/auth/password/reset/`, {
+  const res = await fetch(makeUrl("/users/password/reset/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email }),
@@ -264,10 +288,11 @@ export const requestPasswordReset = async (email) => {
 
 // 🔹 Change Password
 export const changePassword = async (oldPassword, newPassword, confirmNewPassword) => {
-  let token = localStorage.getItem("accessToken");
+  let token =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
   if (!token) throw new Error("User not authenticated");
 
-  let res = await fetch(`${API_BASE_URL}/api/auth/change-password/`, {
+  let res = await fetch(makeUrl("/users/password/change/"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -282,7 +307,7 @@ export const changePassword = async (oldPassword, newPassword, confirmNewPasswor
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(`${API_BASE_URL}/api/auth/change-password/`, {
+    res = await fetch(makeUrl("/users/password/change/"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -302,11 +327,12 @@ export const changePassword = async (oldPassword, newPassword, confirmNewPasswor
 
 // 🔹 Delete account (Right to erasure)
 export const deleteAccount = async () => {
-  let token = localStorage.getItem("accessToken");
+  let token =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
   if (!token) throw new Error("User not authenticated");
 
-  let res = await fetch(`${API_BASE_URL}/api/privacy/erase/`, {
-    method: "POST",
+  let res = await fetch(makeUrl("/users/me/"), {
+    method: "DELETE",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
@@ -315,8 +341,8 @@ export const deleteAccount = async () => {
 
   if (res.status === 401) {
     token = await refreshAccessToken();
-    res = await fetch(`${API_BASE_URL}/api/privacy/erase/`, {
-      method: "POST",
+    res = await fetch(makeUrl("/users/me/"), {
+      method: "DELETE",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
@@ -326,9 +352,16 @@ export const deleteAccount = async () => {
 
   if (!res.ok) {
     let msg = "Failed to delete account";
-    try { const data = await res.json(); msg = data?.message || msg; } catch {}
+    try {
+      const data = await res.json();
+      msg = data?.message || msg;
+    } catch {}
     throw new Error(msg);
   }
 
-  return res.json();
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
 };

--- a/src/lib/userApi.js
+++ b/src/lib/userApi.js
@@ -1,12 +1,16 @@
 import { API_BASE_URL, refreshAccessToken as refreshAccessTokenImported } from "./api";
 
+const makeUrl = (endpoint) =>
+  `${API_BASE_URL}${endpoint.startsWith("/") ? "" : "/"}${endpoint}`;
+
 /**
  * Helper function to perform fetch avec authentification.
  * Ajoute le header Authorization avec le token actuel.
  * Si la réponse est 401, tente de rafraîchir le token et recommence la requête.
  */
 async function fetchWithAuth(url, options = {}) {
-  let token = localStorage.getItem("accessToken");
+  let token =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
   if (!token) {
     throw new Error("User not authenticated");
   }
@@ -32,7 +36,7 @@ async function fetchWithAuth(url, options = {}) {
 
 // 🔹 Login : envoie email et password, récupère et sauvegarde les tokens.
 export async function login(email, password) {
-  const res = await fetch(`${API_BASE_URL}/api/auth/login/`, {
+  const res = await fetch(makeUrl("/users/login/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),
@@ -58,8 +62,10 @@ export async function login(email, password) {
     throw error;
   }
 
-  localStorage.setItem("accessToken", data.access);
-  localStorage.setItem("refreshToken", data.refresh);
+  if (typeof window !== "undefined") {
+    localStorage.setItem("accessToken", data.access);
+    localStorage.setItem("refreshToken", data.refresh);
+  }
   return data;
 }
 
@@ -69,14 +75,16 @@ export const refreshAccessToken = refreshAccessTokenImported;
 
 // 🔹 Logout : supprime les tokens et redirige vers la page de login.
 export function logout() {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
-  window.location.href = "/login";
+  if (typeof window !== "undefined") {
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+    window.location.href = "/login";
+  }
 }
 
 // 🔹 Register User : enregistre un nouvel utilisateur.
 export async function registerUser(userData) {
-  const res = await fetch(`${API_BASE_URL}/api/auth/register/`, {
+  const res = await fetch(makeUrl("/users/register/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(userData),
@@ -91,7 +99,7 @@ export async function registerUser(userData) {
 
 // 🔹 Fetch User Profile : récupère les informations de l'utilisateur connecté.
 export async function fetchUserProfile() {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/auth/me/`, {
+  const res = await fetchWithAuth(makeUrl("/users/me/"), {
     method: "GET",
   });
 
@@ -105,8 +113,8 @@ export async function updatePreferences({ language, currency, timezone }) {
   if (language !== undefined) body.language = language;
   if (currency !== undefined) body.currency = currency;
   if (timezone !== undefined) body.timezone = timezone;
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/auth/preferences/`, {
-    method: "POST",
+  const res = await fetchWithAuth(makeUrl("/users/me/"), {
+    method: "PATCH",
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -120,7 +128,7 @@ export async function updatePreferences({ language, currency, timezone }) {
 
 // 🔹 Reset Password Request : envoie un email pour réinitialiser le mot de passe.
 export async function resetPassword(email) {
-  const res = await fetch(`${API_BASE_URL}/api/auth/reset-password/`, {
+  const res = await fetch(makeUrl("/users/password/reset/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email }),
@@ -134,7 +142,7 @@ export async function resetPassword(email) {
 
 // 🔹 Confirm Password Reset : confirme la réinitialisation du mot de passe avec un token.
 export async function confirmPasswordReset(token, newPassword) {
-  const res = await fetch(`${API_BASE_URL}/api/auth/reset-password/confirm/`, {
+  const res = await fetch(makeUrl("/users/password/reset/confirm/"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token, new_password: newPassword }),
@@ -146,7 +154,7 @@ export async function confirmPasswordReset(token, newPassword) {
 
 // 🔹 Change Password : modifie le mot de passe de l'utilisateur connecté.
 export async function changePassword(oldPassword, newPassword) {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/auth/password/change/`, {
+  const res = await fetchWithAuth(makeUrl("/users/password/change/"), {
     method: "POST",
     body: JSON.stringify({
       old_password: oldPassword,
@@ -164,7 +172,7 @@ export async function changePassword(oldPassword, newPassword) {
 
 // 🔹 Get Users : récupère la liste de tous les utilisateurs.
 export async function getUsers() {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/users/`, {
+  const res = await fetchWithAuth(makeUrl("/users/"), {
     method: "GET",
   });
   if (!res.ok) throw new Error("Failed to fetch users");
@@ -173,7 +181,7 @@ export async function getUsers() {
 
 // 🔹 Get User By ID : récupère les informations d'un utilisateur à partir de son ID.
 export async function getUserById(userId) {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/users/${userId}/`, {
+  const res = await fetchWithAuth(makeUrl(`/users/${userId}/`), {
     method: "GET",
   });
   if (!res.ok) throw new Error(`Failed to fetch user ${userId}`);
@@ -182,7 +190,7 @@ export async function getUserById(userId) {
 
 // 🔹 Update User Profile : met à jour le profil utilisateur via un PUT.
 export async function updateUserProfile(userId, data) {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/users/${userId}/`, {
+  const res = await fetchWithAuth(makeUrl(`/users/${userId}/`), {
     method: "PUT",
     body: JSON.stringify(data),
   });
@@ -192,7 +200,7 @@ export async function updateUserProfile(userId, data) {
 
 // 🔹 Delete User : supprime un utilisateur à partir de son ID.
 export async function deleteUser(userId) {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/users/${userId}/`, {
+  const res = await fetchWithAuth(makeUrl(`/users/${userId}/`), {
     method: "DELETE",
   });
   if (!res.ok) throw new Error(`Failed to delete user ${userId}`);
@@ -202,22 +210,21 @@ export async function deleteUser(userId) {
 // ---------- Follows (athletes) ----------
 
 export async function listFollows() {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/follows/`, { method: "GET" });
+  const res = await fetchWithAuth(makeUrl("/me/follows/"), { method: "GET" });
   if (!res.ok) throw new Error("Failed to list follows");
   return res.json();
 }
 
 export async function followAthlete(athleteId) {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/follows/`, {
+  const res = await fetchWithAuth(makeUrl(`/athletes/${athleteId}/follow/`), {
     method: "POST",
-    body: JSON.stringify({ athlete: athleteId }),
   });
   if (!res.ok) throw new Error("Failed to follow athlete");
-  return res.json();
+  return res.json().catch(() => ({}));
 }
 
-export async function unfollow(followId) {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/follows/${followId}/`, {
+export async function unfollow(athleteId) {
+  const res = await fetchWithAuth(makeUrl(`/athletes/${athleteId}/follow/`), {
     method: "DELETE",
   });
   if (!res.ok) throw new Error("Failed to unfollow athlete");
@@ -226,19 +233,13 @@ export async function unfollow(followId) {
 
 // 🔹 Followed athletes (hydrated Athlete objects)
 export async function getFollowedAthletes() {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/followed/athletes/`, { method: "GET" });
-  if (!res.ok) throw new Error("Failed to fetch followed athletes");
-  const data = await res.json();
-  return Array.isArray(data) ? data : (data.results || []);
+  const data = await listFollows();
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.results)) return data.results;
+  return [];
 }
 
 // 🔹 Unfollow by athlete UUID (no need to know follow id)
 export async function unfollowByAthlete(athleteId) {
-  const res = await fetchWithAuth(`${API_BASE_URL}/api/follows/by-athlete/${athleteId}/`, {
-    method: "DELETE",
-  });
-  if (!res.ok && res.status !== 200 && res.status !== 204) {
-    throw new Error("Failed to unfollow by athlete");
-  }
-  return true;
+  return unfollow(athleteId);
 }

--- a/src/lib/userApi.js
+++ b/src/lib/userApi.js
@@ -1,7 +1,9 @@
-import { API_BASE_URL, refreshAccessToken as refreshAccessTokenImported } from "./api";
+import {
+  makeApiUrl,
+  refreshAccessToken as refreshAccessTokenImported,
+} from "./api";
 
-const makeUrl = (endpoint) =>
-  `${API_BASE_URL}${endpoint.startsWith("/") ? "" : "/"}${endpoint}`;
+const makeUrl = makeApiUrl;
 
 /**
  * Helper function to perform fetch avec authentification.


### PR DESCRIPTION
## Summary
- normalise the frontend API base URL and share a helper to build endpoints against the documented /api prefix
- update auth, user profile and password helpers to call the new /users/* endpoints and guard browser-only storage access
- refresh follow helper functions to target the documented /me/follows and /athletes/{id}/follow routes and adjust the auth context refresh logic

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcfe6e368832ebcad59f2cb976eec