### PR TITLE
Refactor form utilities and replace legacy images

### DIFF
--- a/src/app/(private)/athletes/[slug]/page.jsx
+++ b/src/app/(private)/athletes/[slug]/page.jsx
@@ -6,7 +6,6 @@ import { followAthlete, unfollowAthlete } from "@/lib/api";
 
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
 import { useEffect, useState } from "react";
 import { BadgeCheck, Instagram, Facebook, Youtube, MapIcon, Check, ThumbsUp, User as UserIcon } from "lucide-react";
 import FollowerGrowthChart from "@/components/bar-chart";
@@ -26,6 +25,7 @@ import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carouse
 import { NavUser } from "@/components/nav-user";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { Globe, Euro, ChevronDown, Calendar as CalendarIcon, MapPin, Users, Image as ImageIcon } from "lucide-react";
+import ResponsiveImage from "@/components/responsive-image";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import AthleteProfileHeader from "@/components/athlete-profile";
 import PageHeader from "@/components/page-header";
@@ -729,11 +729,14 @@ export default function AthletePage() {
             <ul role="list" className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 lg:grid-cols-4 xl:gap-x-8">
               {(athlete.images || []).map((src, idx) => (
                 <li key={`${src}-${idx}`} className="relative">
-                  <div className="group overflow-hidden rounded-lg bg-gray-100 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-indigo-600 dark:bg-gray-800 dark:focus-within:outline-indigo-500">
-                    <img
-                      alt=""
+                  <div className="group relative overflow-hidden rounded-lg bg-gray-100 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-indigo-600 dark:bg-gray-800 dark:focus-within:outline-indigo-500">
+                    <ResponsiveImage
+                      alt={`${athlete.name} - photo ${idx + 1}`}
                       src={src}
-                      className="pointer-events-none aspect-[10/7] rounded-lg object-cover outline -outline-offset-1 outline-black/5 group-hover:opacity-75 dark:outline-white/10"
+                      fill
+                      className="aspect-[10/7] rounded-lg"
+                      imageClassName="pointer-events-none rounded-lg object-cover outline -outline-offset-1 outline-black/5 group-hover:opacity-75 dark:outline-white/10"
+                      sizes="(min-width: 1280px) 25vw, (min-width: 768px) 33vw, 100vw"
                     />
                     <button type="button" className="absolute inset-0 focus:outline-hidden">
                       <span className="sr-only">Voir {athlete.name}</span>
@@ -766,11 +769,14 @@ export default function AthletePage() {
                   </div>
                   <div className="grid grid-cols-3 gap-2">
                     {(athlete.images || []).slice(0, 3).map((src, i) => (
-                      <img
+                      <ResponsiveImage
                         key={`${platform}-${i}`}
                         src={src}
                         alt={`${platform} post ${i + 1}`}
-                        className="w-full h-24 object-cover rounded-lg"
+                        fill
+                        className="h-24 w-full"
+                        imageClassName="object-cover rounded-lg"
+                        sizes="(min-width: 768px) 33vw, 100vw"
                       />
                     ))}
                   </div>

--- a/src/app/(private)/followed/page.jsx
+++ b/src/app/(private)/followed/page.jsx
@@ -5,7 +5,6 @@
 // follower growth, trophies, photos, etc.).
 
 import { useMemo, useState, useEffect } from "react";
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -27,6 +26,7 @@ import {
   User,
 } from "lucide-react";
 
+import ResponsiveImage from "@/components/responsive-image";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import PageHeader from "@/components/page-header";
 import { Button } from "@/components/ui/button";
@@ -150,10 +150,13 @@ export default function FollowedFeedPage() {
                           <span aria-hidden="true" className="absolute inset-0" />
                           <div className="relative">
                             {images?.[0] ? (
-                              <img
-                                alt=""
+                              <ResponsiveImage
+                                alt={`${a.name} avatar`}
                                 src={images[0]}
-                                className="size-20 rounded-full bg-gray-300 outline -outline-offset-1 outline-black/5 dark:bg-gray-700 dark:outline-white/10"
+                                fill
+                                className="size-20"
+                                imageClassName="rounded-full bg-gray-300 outline -outline-offset-1 outline-black/5 dark:bg-gray-700 dark:outline-white/10"
+                                sizes="80px"
                               />
                             ) : (
                               <div className="size-20 rounded-full bg-muted" />
@@ -259,12 +262,13 @@ function FeedCard({ item }) {
   return (
     <article className="bg-white dark:bg-zinc-900 rounded-xl p-4 shadow border border-transparent">
       <header className="flex items-start gap-3 mb-3">
-        <Image
+        <ResponsiveImage
           src={item.athlete.avatar}
           alt={item.athlete.name}
-          width={40}
-          height={40}
-          className="rounded-full object-cover"
+          fill
+          className="size-10"
+          imageClassName="rounded-full object-cover"
+          sizes="40px"
         />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
@@ -334,12 +338,20 @@ function PostBody({ item }) {
       {item.images?.length ? (
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           {item.images.map((src, i) => (
-            <Image key={i} src={src} alt="post" width={300} height={200} className="w-full h-32 object-cover rounded-lg" />
+            <ResponsiveImage
+              key={i}
+              src={src}
+              alt="post"
+              fill
+              className="h-32 w-full"
+              imageClassName="object-cover rounded-lg"
+              sizes="(min-width: 768px) 33vw, 100vw"
+            />
           ))}
         </div>
       ) : null}
       <div className="flex items-center gap-3 mt-3 text-sm text-muted-foreground">
-        <button className="flex items-center gap-1 hover:text-foreground"><Heart className="w-4 h-4" /> J'aime</button>
+        <button className="flex items-center gap-1 hover:text-foreground"><Heart className="w-4 h-4" /> J&apos;aime</button>
         <button className="flex items-center gap-1 hover:text-foreground"><MessageSquare className="w-4 h-4" /> Commenter</button>
       </div>
     </div>
@@ -388,7 +400,15 @@ function PhotoBody({ item }) {
       {item.caption && <p className="mb-3">{item.caption}</p>}
       <div className="grid grid-cols-3 gap-2">
         {item.images?.map((src, i) => (
-          <Image key={i} src={src} alt="photo" width={300} height={200} className="w-full h-28 object-cover rounded-lg" />
+          <ResponsiveImage
+            key={i}
+            src={src}
+            alt="photo"
+            fill
+            className="h-28 w-full"
+            imageClassName="object-cover rounded-lg"
+            sizes="(min-width: 768px) 33vw, 100vw"
+          />
         ))}
       </div>
     </div>

--- a/src/app/page-old.jsx
+++ b/src/app/page-old.jsx
@@ -8,11 +8,12 @@
  */
 
 // React Imports
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 // Next.js Imports
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 
 // Third-Party Library Imports
 import {
@@ -31,43 +32,19 @@ import {
   Globe,
   Euro,
   ChevronDown,
+  Handshake,
+  MessageSquare,
+  Sparkles,
+  User,
+  MapIcon,
 } from "lucide-react";
 import { motion } from "framer-motion";
 
 // UI Components
 import { Button } from "@/components/ui/button";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import Logo from "@/components/ui/logo";
-
-// Hooks
-import { useCurrentUser } from "@/hooks/useCurrentUser";
-
-// React Imports
-import { useState, useEffect, useCallback } from "react";
-
-// Next.js Imports
-import Link from "next/link";
-import Image from "next/image";
-import { usePathname } from "next/navigation";
-
-// Third-Party Library Imports
-import {
-  Globe,
-  Euro,
-  ChevronDown,
-  Search,
-  Handshake,
-  MessageSquare,
-  Heart,
-  Sparkles,
-  User,
-  MapIcon,
-} from "lucide-react";
-
-// UI Components
-import { Button } from "@/components/ui/button";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import Logo from "@/components/ui/logo";
 import Skeleton from "@/components/skeleton-item";
 
@@ -75,8 +52,6 @@ import Skeleton from "@/components/skeleton-item";
 import { NavUser } from "@/components/nav-user";
 import { NavMenu } from "@/components/nav-bar";
 import AthletesTabs from "@/components/athletes-tabs";
-
-// Charts
 
 // Hooks
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -437,7 +412,7 @@ export default function Page() {
     content = (
       <div className="flex flex-col items-center justify-center py-16 text-center gap-4">
         <p className="text-sm text-muted-foreground max-w-md">
-          Aucun athlète n'est disponible pour le moment. Revenez plus tard ou actualisez la page.
+          Aucun athlète n&apos;est disponible pour le moment. Revenez plus tard ou actualisez la page.
         </p>
         <Button onClick={loadAthletes} variant="outline">
           Actualiser

--- a/src/components/athlete-profile.jsx
+++ b/src/components/athlete-profile.jsx
@@ -20,13 +20,6 @@ import {
 } from "lucide-react";
 
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-
-import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
@@ -34,7 +27,34 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import ResponsiveImage from "@/components/responsive-image";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
+/**
+ * AthleteProfileHeader renders the hero section of an athlete profile page.
+ * It displays breadcrumbs, key metadata and a responsive photo collage.
+ *
+ * @param {object} props - Component props.
+ * @param {string} props.title - Page title.
+ * @param {Array<{label: string, href?: string}>} props.breadcrumbs - Ordered breadcrumb trail.
+ * @param {string} props.levelLabel - Label describing the engagement level.
+ * @param {string} [props.ageLabel] - Optional age descriptor.
+ * @param {string} [props.nationalityLabel] - Optional nationality descriptor.
+ * @param {string} props.location - Athlete location label.
+ * @param {string} props.priceLabel - Pricing label for the athlete.
+ * @param {string} props.calendarLabel - Availability label for the calendar badge.
+ * @param {string[]} props.images - Gallery images for the collage.
+ * @param {boolean} props.isFollowed - Whether the athlete is currently followed by the user.
+ * @param {() => void} [props.onToggleFollow] - Callback toggling follow status.
+ * @param {boolean} props.followAnimating - Indicates the follow button animation state.
+ * @param {number} props.followersCount - Number of followers displayed next to the CTA.
+ * @returns {JSX.Element} Hero header for the athlete profile page.
+ */
 export default function AthleteProfileHeader({
   title = "Back End Developer",
   breadcrumbs = [
@@ -203,25 +223,53 @@ export default function AthleteProfileHeader({
         {/* Block 1: visible on all, spans 2/3 on md, 4/6 on lg */}
         <div className="flex p-px md:col-span-2 lg:col-span-4">
           <div className="w-full overflow-hidden rounded-lg bg-white shadow-sm outline outline-black/5 max-lg:rounded-t-4xl lg:rounded-tl-4xl dark:bg-gray-800 dark:shadow-none dark:outline-white/15">
-            <img alt="" src={images[0] || "/images/placeholder.jpg"} className="h-80 w-full object-cover object-center" />
+            <ResponsiveImage
+              alt={`${title} - visuel principal`}
+              src={images[0]}
+              fill
+              className="h-80 w-full"
+              imageClassName="object-cover object-center"
+              sizes="(min-width: 1280px) 66vw, (min-width: 768px) 50vw, 100vw"
+            />
           </div>
         </div>
         {/* Block 2: hidden on base, visible md (1/3) and lg (2/6) */}
         <div className="hidden p-px md:flex md:col-span-1 lg:col-span-2">
           <div className="w-full overflow-hidden rounded-lg bg-white shadow-sm outline outline-black/5 lg:rounded-tr-4xl dark:bg-gray-800 dark:shadow-none dark:outline-white/15">
-            <img alt="" src={images[1] || images[0] || "/images/placeholder.jpg"} className="h-80 w-full object-cover object-center" />
+            <ResponsiveImage
+              alt={`${title} - visuel secondaire`}
+              src={images[1] || images[0]}
+              fill
+              className="h-80 w-full"
+              imageClassName="object-cover object-center"
+              sizes="(min-width: 1280px) 33vw, (min-width: 768px) 25vw, 100vw"
+            />
           </div>
         </div>
         {/* Block 3: only visible on lg (2/6) */}
         <div className="hidden p-px lg:flex lg:col-span-2">
           <div className="w-full overflow-hidden rounded-lg bg-white shadow-sm outline outline-black/5 lg:rounded-bl-4xl dark:bg-gray-800 dark:shadow-none dark:outline-white/15">
-            <img alt="" src={images[2] || images[0] || "/images/placeholder.jpg"} className="h-80 w-full object-cover object-center" />
+            <ResponsiveImage
+              alt={`${title} - visuel galerie`}
+              src={images[2] || images[0]}
+              fill
+              className="h-80 w-full"
+              imageClassName="object-cover object-center"
+              sizes="(min-width: 1280px) 33vw, (min-width: 768px) 25vw, 100vw"
+            />
           </div>
         </div>
         {/* Block 4: only visible on lg (4/6) */}
         <div className="hidden p-px lg:flex lg:col-span-4">
           <div className="w-full overflow-hidden rounded-lg bg-white shadow-sm outline outline-black/5 max-lg:rounded-b-4xl lg:rounded-br-4xl dark:bg-gray-800 dark:shadow-none dark:outline-white/15">
-            <img alt="" src={images[3] || images[1] || "/images/placeholder.jpg"} className="h-80 w-full object-cover object-center" />
+            <ResponsiveImage
+              alt={`${title} - visuel additionnel`}
+              src={images[3] || images[1] || images[0]}
+              fill
+              className="h-80 w-full"
+              imageClassName="object-cover object-center"
+              sizes="(min-width: 1280px) 66vw, (min-width: 768px) 50vw, 100vw"
+            />
           </div>
         </div>
       </div>

--- a/src/components/forms/form-field-error.jsx
+++ b/src/components/forms/form-field-error.jsx
@@ -1,0 +1,69 @@
+"use client";
+
+import PropTypes from "prop-types";
+import { AnimatePresence, motion } from "framer-motion";
+import { XCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * FormFieldError renders an animated inline error indicator optionally accompanied by a message.
+ * It centralises the animation logic shared by several forms to keep the JSX focused on business rules.
+ *
+ * @param {object} props - Component props.
+ * @param {string} [props.message] - Validation message displayed below the input.
+ * @param {boolean} [props.showIcon=true] - Whether the error icon should be displayed alongside the field label.
+ * @param {string} [props.className] - Additional Tailwind classes applied to the wrapper element.
+* @param {string} [props.iconClassName] - Extra classes applied to the error icon container.
+ * @param {boolean} [props.showMessage=true] - Whether the inline error message should accompany the icon.
+ * @returns {JSX.Element|null} Animated error indicator and message.
+ */
+export default function FormFieldError({
+  message,
+  showIcon = true,
+  className,
+  iconClassName,
+  showMessage = true,
+}) {
+  if (!message && !showIcon) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-col", className)}>
+      <AnimatePresence>
+        {showIcon && message ? (
+          <motion.span
+            initial={{ opacity: 0, x: -5 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -5 }}
+            transition={{ duration: 0.2 }}
+            className={cn("flex items-center text-destructive", iconClassName)}
+          >
+            <XCircle className="mr-1 h-4 w-4" />
+            {showMessage ? <span className="text-xs font-medium">{message}</span> : null}
+          </motion.span>
+        ) : null}
+      </AnimatePresence>
+      {!showIcon && message ? (
+        <motion.p
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -4 }}
+          transition={{ duration: 0.2 }}
+          className="text-xs font-medium text-destructive"
+        >
+          {message}
+        </motion.p>
+      ) : null}
+    </div>
+  );
+}
+
+FormFieldError.propTypes = {
+  message: PropTypes.string,
+  showIcon: PropTypes.bool,
+  className: PropTypes.string,
+  iconClassName: PropTypes.string,
+  showMessage: PropTypes.bool,
+};

--- a/src/components/forms/login-form.jsx
+++ b/src/components/forms/login-form.jsx
@@ -7,8 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner"; // Import de sonner pour les notifications
 import { persistAuthTokens } from "@/lib/api";
 import { userEndpoints } from "@/lib/endpoints";
-import { motion, AnimatePresence } from "framer-motion"; // Pour animer les erreurs
-import { Loader, XCircle } from "lucide-react"; // Icones Lucide
+import { Loader } from "lucide-react"; // Icones Lucide
 import { Suspense } from "react";
 
 import { cn } from "@/lib/utils";
@@ -22,6 +21,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import FormFieldError from "@/components/forms/form-field-error";
 
 // 🔹 Définir le schéma de validation avec Zod
 const loginSchema = z.object({
@@ -29,6 +29,14 @@ const loginSchema = z.object({
   password: z.string().min(8, "Password must be at least 8 characters long"),
 });
 
+/**
+ * LoginFormContent renders the SponsorsClub authentication form.
+ * It validates credentials with Zod, persists tokens and redirects on success.
+ *
+ * @param {object} props - Component props forwarded to the root container.
+ * @param {string} [props.className] - Additional Tailwind classes for the wrapper.
+ * @returns {JSX.Element} Interactive login form.
+ */
 export function LoginFormContent({ className, ...props }) {
   const {
     register,
@@ -144,19 +152,11 @@ export function LoginFormContent({ className, ...props }) {
               <div className="grid gap-2">
                 <div className="flex items-center">
                   <Label htmlFor="email">Email</Label>
-                  <AnimatePresence>
-                    {errors.email && (
-                      <motion.div
-                        initial={{ opacity: 0, x: -5 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        exit={{ opacity: 0, x: -5 }}
-                        transition={{ duration: 0.3 }}
-                        className="ml-2"
-                      >
-                        <XCircle className="text-red-500 w-4 h-4" />
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
+                  <FormFieldError
+                    message={errors.email?.message}
+                    iconClassName="ml-2"
+                    showMessage={false}
+                  />
                 </div>
                 <Input
                   id="email"
@@ -164,25 +164,22 @@ export function LoginFormContent({ className, ...props }) {
                   {...register("email")}
                   placeholder="m@example.com"
                 />
+                <FormFieldError
+                  message={errors.email?.message}
+                  showIcon={false}
+                  className="min-h-[1rem]"
+                />
               </div>
 
               {/* Password Input */}
               <div className="grid gap-2">
                 <div className="flex items-center">
                   <Label htmlFor="password">Mot de passe</Label>
-                  <AnimatePresence>
-                    {errors.password && (
-                      <motion.div
-                        initial={{ opacity: 0, x: -5 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        exit={{ opacity: 0, x: -5 }}
-                        transition={{ duration: 0.3 }}
-                        className="ml-2"
-                      >
-                        <XCircle className="text-red-500 w-4 h-4" />
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
+                  <FormFieldError
+                    message={errors.password?.message}
+                    iconClassName="ml-2"
+                    showMessage={false}
+                  />
                   <a
                     href="/reset-password"
                     tabIndex={-1}
@@ -195,6 +192,11 @@ export function LoginFormContent({ className, ...props }) {
                   id="password"
                   type="password"
                   {...register("password")}
+                />
+                <FormFieldError
+                  message={errors.password?.message}
+                  showIcon={false}
+                  className="min-h-[1rem]"
                 />
               </div>
 
@@ -233,6 +235,13 @@ export function LoginFormContent({ className, ...props }) {
 }
 
 // Wrapper component with Suspense
+/**
+ * LoginForm wraps {@link LoginFormContent} with a suspense boundary so the form
+ * can be embedded in server components without triggering hydration warnings.
+ *
+ * @param {object} props - Props forwarded to the content component.
+ * @returns {JSX.Element} Suspense enabled login form.
+ */
 export function LoginForm(props) {
   return (
     <Suspense fallback={<div>Loading...</div>}>

--- a/src/components/forms/register-form.jsx
+++ b/src/components/forms/register-form.jsx
@@ -3,10 +3,9 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner"; // Pour les notifications toast
-import { motion, AnimatePresence } from "framer-motion"; // Pour animer les erreurs
-import { XCircle } from "lucide-react"; // Icône d'erreur
 import { userEndpoints } from "@/lib/endpoints";
 
 import { cn } from "@/lib/utils";
@@ -33,6 +32,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import FormFieldError from "@/components/forms/form-field-error";
 
 // Règles de validation par indicatif
 const PHONE_RULES = {
@@ -78,6 +78,14 @@ const registerSchema = z
 
   });
 
+/**
+ * RegisterForm renders the SponsorsClub onboarding form for agents and collaborators.
+ * It validates input with Zod, normalises phone numbers and calls the register endpoint.
+ *
+ * @param {object} props - Component props.
+ * @param {string} [props.className] - Optional Tailwind classes for the wrapper.
+ * @returns {JSX.Element} Interactive registration form.
+ */
 export function RegisterForm({ className, ...props }) {
   const {
     register,
@@ -144,20 +152,19 @@ export function RegisterForm({ className, ...props }) {
     }
   };
 
-  // Fonction utilitaire pour afficher une icône d'erreur animée
-  const ErrorIcon = () => (
-    <AnimatePresence>
-      <motion.div
-        initial={{ opacity: 0, x: -5 }}
-        animate={{ opacity: 1, x: 0 }}
-        exit={{ opacity: 0, x: -5 }}
-        transition={{ duration: 0.3 }}
-        className="ml-2"
-      >
-        <XCircle className="text-red-500 w-4 h-4" />
-      </motion.div>
-    </AnimatePresence>
+  /**
+   * Renders the animated error indicator displayed next to field labels.
+   *
+   * @param {{ message?: string }} props - Error indicator props.
+   * @returns {JSX.Element|null} Animated error icon.
+   */
+  const ErrorIcon = ({ message }) => (
+    <FormFieldError message={message} iconClassName="ml-2" showMessage={false} />
   );
+
+  ErrorIcon.propTypes = {
+    message: PropTypes.string,
+  };
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -211,19 +218,7 @@ export function RegisterForm({ className, ...props }) {
               <div className="grid gap-2 mt-4 col-span-2">
                 <div className="flex items-center">
                   <Label htmlFor="account_type">Type de compte</Label>
-                  <AnimatePresence>
-                    {errors.account_type && (
-                      <motion.div
-                        initial={{ opacity: 0, x: -5 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        exit={{ opacity: 0, x: -5 }}
-                        transition={{ duration: 0.3 }}
-                        className="ml-2"
-                      >
-                        <XCircle className="text-red-500 w-4 h-4" />
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
+                  <ErrorIcon message={errors.account_type?.message} />
                 </div>
                 <Tabs value={accountType} onValueChange={setAccountType} className="w-full">
                   <TabsList className="w-full">
@@ -238,6 +233,7 @@ export function RegisterForm({ className, ...props }) {
                   </TabsList>
                 </Tabs>
                 <input type="hidden" {...register("account_type")} value={accountType} readOnly />
+                <FormFieldError message={errors.account_type?.message} showIcon={false} />
               </div>
             </div>
 
@@ -245,13 +241,10 @@ export function RegisterForm({ className, ...props }) {
             <div className="grid gap-2 mt-4">
               <div className="flex items-center">
                 <Label htmlFor="email">Email</Label>
-                <AnimatePresence>
-                  {errors.email && <motion.div initial={{ opacity: 0, x: -5 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -5 }} transition={{ duration: 0.3 }} className="ml-2">
-                    <XCircle className="text-red-500 w-4 h-4" />
-                  </motion.div>}
-                </AnimatePresence>
+                <ErrorIcon message={errors.email?.message} />
               </div>
               <Input id="email" type="email" {...register("email")} />
+              <FormFieldError message={errors.email?.message} showIcon={false} />
             </div>
 
 
@@ -260,11 +253,7 @@ export function RegisterForm({ className, ...props }) {
               <div className="grid col-span-3 gap-2">
                 <div className="flex items-center">
                   <Label htmlFor="phone_country_code">Indicatif</Label>
-                  <AnimatePresence>
-                    {errors.phone_country_code && <motion.div initial={{ opacity: 0, x: -5 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -5 }} transition={{ duration: 0.3 }} className="ml-2">
-                      <XCircle className="text-red-500 w-4 h-4" />
-                    </motion.div>}
-                  </AnimatePresence>
+                  <ErrorIcon message={errors.phone_country_code?.message} />
                 </div>
                 <Select value={phoneCode} onValueChange={(val) => setPhoneCode(val)}>
                   <SelectTrigger className="h-9">
@@ -276,59 +265,48 @@ export function RegisterForm({ className, ...props }) {
                     <SelectItem value="+44">🇬🇧 +44</SelectItem>
                   </SelectContent>
                 </Select>
-                {/* Champ caché pour intégrer à react-hook-form */}
                 <input type="hidden" {...register("phone_country_code")} value={phoneCode} readOnly />
+                <FormFieldError message={errors.phone_country_code?.message} showIcon={false} />
               </div>
 
               <div className="grid col-span-5 gap-2">
                 <div className="flex items-center">
                   <Label htmlFor="phone_number">Numéro de téléphone</Label>
-                  <AnimatePresence>
-                    {errors.phone_number && <motion.div initial={{ opacity: 0, x: -5 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -5 }} transition={{ duration: 0.3 }} className="ml-2">
-                      <XCircle className="text-red-500 w-4 h-4" />
-                    </motion.div>}
-                  </AnimatePresence>
+                  <ErrorIcon message={errors.phone_number?.message} />
                 </div>
                 <Input
                   id="phone_number"
                   placeholder={PHONE_RULES[phoneCode]?.example || "ex: numéro"}
                   {...register("phone_number")}
                   onChange={(e) => {
-                    // Autoriser seulement les chiffres à l'entrée
                     const digits = e.target.value.replace(/\D/g, "");
-                    // Limiter selon l'indicatif sélectionné
                     const rule = PHONE_RULES[phoneCode];
                     const limited = rule ? digits.slice(0, rule.max) : digits.slice(0, 15);
                     e.target.value = limited;
                   }}
                 />
-                </div>
+                <FormFieldError message={errors.phone_number?.message} showIcon={false} />
+              </div>
             </div>
 
             {/* Password */}
             <div className="grid gap-2 mt-4">
               <div className="flex items-center">
                 <Label htmlFor="password">Mot de passe</Label>
-                <AnimatePresence>
-                  {errors.password && <motion.div initial={{ opacity: 0, x: -5 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -5 }} transition={{ duration: 0.3 }} className="ml-2">
-                    <XCircle className="text-red-500 w-4 h-4" />
-                  </motion.div>}
-                </AnimatePresence>
+                <ErrorIcon message={errors.password?.message} />
               </div>
               <Input id="password" type="password" {...register("password")} />
+              <FormFieldError message={errors.password?.message} showIcon={false} />
             </div>
 
             {/* Confirm Password */}
             <div className="grid gap-2 mt-4">
               <div className="flex items-center">
                 <Label htmlFor="confirm_password">Confirmer le mot de passe</Label>
-                <AnimatePresence>
-                  {errors.confirm_password && <motion.div initial={{ opacity: 0, x: -5 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -5 }} transition={{ duration: 0.3 }} className="ml-2">
-                    <XCircle className="text-red-500 w-4 h-4" />
-                  </motion.div>}
-                </AnimatePresence>
+                <ErrorIcon message={errors.confirm_password?.message} />
               </div>
               <Input id="confirm_password" type="password" {...register("confirm_password")} />
+              <FormFieldError message={errors.confirm_password?.message} showIcon={false} />
             </div>
 
             {/* Bouton de soumission */}

--- a/src/components/language-currency-modal.jsx
+++ b/src/components/language-currency-modal.jsx
@@ -20,6 +20,15 @@ const currencies = [
   { code: "USD", name: "US Dollar", symbol: "$", flag: "🇺🇸" },
 ];
 
+/**
+ * LanguageCurrencyModal lets a signed-in user configure language and currency preferences.
+ * Preferences are persisted via the user endpoints and immediately reflected in the UI.
+ *
+ * @param {object} props - Component properties.
+ * @param {boolean} props.open - Controls the visibility of the modal dialog.
+ * @param {(open: boolean) => void} props.onOpenChange - Callback executed when the modal visibility toggles.
+ * @returns {JSX.Element} A modal with tabs to select language and currency.
+ */
 export function LanguageCurrencyModal({ open, onOpenChange }) {
   const { user } = useCurrentUser();
   const [selectedLanguage, setSelectedLanguage] = useState("fr");
@@ -81,7 +90,7 @@ export function LanguageCurrencyModal({ open, onOpenChange }) {
       // Delay measurement to ensure content is rendered
       setTimeout(measureHeight, 10);
     }
-  }, [activeTab, open, user]);
+  }, [activeTab, open, selectedCurrency, selectedLanguage, user]);
 
   const handleSave = async () => {
     try {

--- a/src/components/nav-user.jsx
+++ b/src/components/nav-user.jsx
@@ -77,7 +77,6 @@ export function NavUser({ user: userProp = null }) {
   const [loadingProfile, setLoadingProfile] = useState(!userProp);
 
   useEffect(() => {
-    console.log("NavUser: userProp changed", user);
     if (userProp) {
       setUser(userProp);
       setLoadingProfile(false);

--- a/src/components/responsive-image.jsx
+++ b/src/components/responsive-image.jsx
@@ -1,0 +1,88 @@
+"use client";
+
+import Image from "next/image";
+import PropTypes from "prop-types";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * ResponsiveImage is a thin wrapper around Next.js' {@link Image} component that simplifies
+ * rendering optimized images while preserving Tailwind based sizing utilities.
+ * It supports both fixed-dimension and `fill` layouts so that existing CSS driven
+ * layouts can keep working after migrating away from the native `<img>` element
+ * required by the ESLint `@next/next/no-img-element` rule.
+ *
+ * @param {object} props - Component props.
+ * @param {string|null|undefined} props.src - Source URL of the image. When falsy a placeholder is used.
+ * @param {string} props.alt - Accessible alternative text describing the image content.
+ * @param {string} [props.className] - Additional classes applied to the container when using `fill` layout or directly to the image otherwise.
+ * @param {string} [props.imageClassName] - Extra classes applied to the `Image` element.
+ * @param {number} [props.width=800] - Width used for the fixed layout in pixels.
+ * @param {number} [props.height=600] - Height used for the fixed layout in pixels.
+ * @param {boolean} [props.fill=false] - Whether the image should fill its container.
+ * @param {string} [props.sizes="100vw"] - The responsive sizes attribute forwarded to Next.js.
+ * @param {boolean} [props.priority=false] - Whether the image should be considered high priority by Next.js.
+ * @param {boolean} [props.unoptimized=true] - Disables Next.js optimisations to support arbitrary remote hosts.
+ * @param {string} [props.fallbackSrc="/images/placeholder.jpg"] - Fallback URL if `src` is not provided.
+ * @returns {JSX.Element} A responsive image element leveraging Next.js optimisations when possible.
+ */
+export function ResponsiveImage({
+  src,
+  alt,
+  className,
+  imageClassName,
+  width = 800,
+  height = 600,
+  fill = false,
+  sizes = "100vw",
+  priority = false,
+  unoptimized = true,
+  fallbackSrc = "/images/placeholder.jpg",
+}) {
+  const resolvedSrc = src || fallbackSrc;
+
+  if (fill) {
+    return (
+      <div className={cn("relative", className)}>
+        <Image
+          src={resolvedSrc}
+          alt={alt}
+          fill
+          sizes={sizes}
+          priority={priority}
+          unoptimized={unoptimized}
+          className={cn("object-cover", imageClassName)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={resolvedSrc}
+      alt={alt}
+      width={width}
+      height={height}
+      sizes={sizes}
+      priority={priority}
+      unoptimized={unoptimized}
+      className={imageClassName ? cn(imageClassName, className) : className}
+    />
+  );
+}
+
+ResponsiveImage.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  imageClassName: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  fill: PropTypes.bool,
+  sizes: PropTypes.string,
+  priority: PropTypes.bool,
+  unoptimized: PropTypes.bool,
+  fallbackSrc: PropTypes.string,
+};
+
+export default ResponsiveImage;

--- a/src/lib/endpoints.js
+++ b/src/lib/endpoints.js
@@ -233,7 +233,7 @@ export const utilityEndpoints = {
     apiRequest("/auth/reset-password/confirm/", { method: "POST", body: payload }),
 };
 
-export default {
+const endpoints = {
   analytics: analyticsEndpoints,
   athletes: athleteEndpoints,
   clauses: clauseTemplateEndpoints,
@@ -248,3 +248,5 @@ export default {
   users: userEndpoints,
   utilities: utilityEndpoints,
 };
+
+export default endpoints;


### PR DESCRIPTION
## Summary
- replace legacy `<img>` usage across athlete and feed pages with a reusable `ResponsiveImage` wrapper and add docstrings
- extract an animated `FormFieldError` helper and refactor login/register forms to use it while improving validation messaging
- address eslint warnings by updating language modal dependencies, cleaning imports, and fixing anonymous default exports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e428b82c84832eb60402154aac6f8e